### PR TITLE
Learn more link under SSL configuration blade now points to Oracle We…

### DIFF
--- a/addnode/src/main/arm/addnodedeploy.parameters.json
+++ b/addnode/src/main/arm/addnodedeploy.parameters.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "_artifactsLocation": {
+      "value":"GEN-UNIQUE"
+    },
     "aadsSettings": {
       "value": {
         "enable": true,
@@ -39,7 +42,7 @@
     "numberOfExistingNodes": {
       "value": "GEN-UNIQUE"
     },
-    "numberOfNodes": {
+    "numberOfNewNodes": {
       "value": "GEN-UNIQUE"
     },
     "skuUrnVersion": {
@@ -78,4 +81,3 @@
     }
   }
 }
-

--- a/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-oraclelinux-wls-cluster/src/main/arm/createUiDefinition.json
@@ -318,7 +318,7 @@
 							"text": "Selecting 'Yes' here will cause the template to provision WebLogic Administration Console on HTTPS (Secure) Port, with your own SSL Certificate provided by a Certifying Authority.",
 							"link": {
 								"label": "Learn more",
-								"uri": "https://aka.ms/arm-oraclelinux-wls-cluster-app-gateway-overview"
+								"uri": "https://aka.ms/arm-oraclelinux-wls-ssl-config"
 							}
 						}
 					},


### PR DESCRIPTION
WebLogic Server SSL Overview documentation page (#119)

* Corrected parameter names for Custom SSL configuration for AddNode feature

* learn more link under SSL configuration blade now points to Oracle WebLogic Server SSL Overview documentation page

* updated addnode parameters json as per the latest mainTemplate.json file

* I created an aka.ms link that redirects to the correct document.

Co-authored-by: gnsuryan <gnsuryan@users.noreply.github.com>
Co-authored-by: Ed Burns <edburns@microsoft.com>